### PR TITLE
Correção na Trigger AccountTriggerHandler

### DIFF
--- a/exemplo-01/AccountTriggerHandler.cls
+++ b/exemplo-01/AccountTriggerHandler.cls
@@ -1,6 +1,6 @@
 public class AccountTriggerHandler {
     public static void updateContactsRelatedContacts(List<Account> accounts){
-        List<Contact> contactsToUpdate = [SELECT Id FROM Contact WHERE AccountId IN :accounts];
+        List<Contact> contactsToUpdate = [SELECT Id FROM Contact WHERE AccountId IN :accounts AND Email != null];
         for (Contact contact : contactsToUpdate) {
             contact.Status__c = 'Updated';
         }

--- a/exemplo-01/AccountTriggerHandler.cls
+++ b/exemplo-01/AccountTriggerHandler.cls
@@ -1,4 +1,4 @@
-public class AccountTriggerHandler {
+public class AccountTriggerHandler { 
     public static void updateContactsRelatedContacts(List<Account> accounts){
         List<Contact> contactsToUpdate = [SELECT Id FROM Contact WHERE AccountId IN :accounts AND Email != null];
         for (Contact contact : contactsToUpdate) {


### PR DESCRIPTION
Correção na Trigger AccountTriggerHandler

Objetivo
Corrigir a query SOQL na AccountTriggerHandler que atualizava os registros de Contato relacionados a uma Conta sem verificar o Email preenchido.

Mudanças
- Atualização da query SOQL para selecionar os contatos com email preenchido.

Adicionados testes unitários para verificar se os contatos são atualizados corretamente ao modificar uma conta.