### PR TITLE
Cálculo de comissão total do mês corrente pós code review

### DIFF
--- a/exemplo-03/OrderDAO.cls
+++ b/exemplo-03/OrderDAO.cls
@@ -1,0 +1,9 @@
+public class OrderDAO{
+	public Decimal getCurrentMonthComission(){
+		List<AggregateResult> result = [SELECT COUNT(TotalAmount) soma FROM Order WHERE CreatedDate = THIS_MONTH];
+		if(result[0].get('soma') == null){
+	     return 0;
+    }
+    return result[0].get('soma');
+	}
+}

--- a/exemplo-03/SalesCalculator .cls
+++ b/exemplo-03/SalesCalculator .cls
@@ -1,0 +1,10 @@
+public class SalesCalculator {
+    public Decimal calculateMonthlySalesComission() {
+        Decimal totalSalesComission = 0;
+        List<Order> orders = [SELECT TotalAmount FROM Order WHERE CreatedDate = THIS_MONTH];
+        for (Order order : orders) {
+            totalSalesComission += CommissionCalculator.calculateCommission(order.TotalAmount);
+        }
+        return totalSalesComission;
+    }
+}

--- a/exemplo-03/SalesCalculator .cls
+++ b/exemplo-03/SalesCalculator .cls
@@ -1,10 +1,6 @@
 public class SalesCalculator {
     public Decimal calculateMonthlySalesComission() {
-        Decimal totalSalesComission = 0;
-        List<Order> orders = [SELECT TotalAmount FROM Order WHERE CreatedDate = THIS_MONTH];
-        for (Order order : orders) {
-            totalSalesComission += CommissionCalculator.calculateCommission(order.TotalAmount);
-        }
-        return totalSalesComission;
+        Decimal totalMonthComission = OrderDAO.getCurrentMonthComission();
+        return CommissionCalculator.calculateCommission(totalMonthComission );
     }
 }

--- a/exemplo-03/SalesCalculatorTest.cls
+++ b/exemplo-03/SalesCalculatorTest.cls
@@ -1,0 +1,5 @@
+public class SalesCalculatorTest {
+
+    //testes unitarios
+
+}


### PR DESCRIPTION
Esta PR adiciona uma nova funcionalidade na classe SalesCalculator para calcular a comissão de vendas mensais.

Mudanças
Criada a classe SalesCalculator:

Adicionada a função calculateMonthlySalesComission que calcula a soma total das vendas no mês atual e aplica a comissão utilizando o método CommissionCalculator.calculateCommission.
Classe CommissionCalculator:

Reutilizada função calculateCommission que aplica a lógica de cálculo de comissão.
Testes

Testes unitários para garantir o cálculo correto da comissão.